### PR TITLE
Release v3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ export default [
 
 Defines a directory that follows the FSD methodology. If not specified, the root directory will default to the directory containing the ESLint configuration file or the path passed with the `cwd` linter option.
 
-The value must be an absolute path to a folder with the layers. Files and folders lying directly in this directory will be considered as layers.
+The value can be an absolute path or a relative path (resolved relative to the directory containing the ESLint configuration file) to the folder with the layers. Files and folders lying directly in this directory will be considered as layers.
 
 For example, if your FSD layers are located in the `src` folder in the same directory as the ESLint configuration file, the `rootDir` option should be set as follows:
 
@@ -99,7 +99,7 @@ export default [
   {
     settings: {
       fsd: {
-        rootDir: `${__dirname}/src`,
+        rootDir: './src',
       },
     },
   },
@@ -127,12 +127,12 @@ export default [
   {
     settings: {
       fsd: {
-        rootDir: `${__dirname}/src`,
+        rootDir: './scr',
         aliases: {
-          // @/features/foo/bar -> <__dirname>/src/features/foo/bar
+          // @/features/foo/bar -> ./src/features/foo/bar
           '@/*': './src/*',
 
-          // foo -> <__dirname>/vendor/foo
+          // foo -> ./vendor/foo
           foo: './vendor/foo',
 
           // bar -> /bar
@@ -232,7 +232,7 @@ export default [
     },
     settings: {
       fsd: {
-        rootDir: `${__dirname}/src`,
+        rootDir: './src',
         aliases: {
           '@/*': './src/*',
         },
@@ -329,7 +329,7 @@ export default [
     },
     settings: {
       fsd: {
-        rootDir: `${__dirname}/src`,
+        rootDir: './src',
         aliases: {
           '@/*': './src/*',
         },
@@ -429,7 +429,7 @@ export default [
     },
     settings: {
       fsd: {
-        rootDir: `${__dirname}/src`,
+        rootDir: './src',
         aliases: {
           '@/*': './src/*',
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-import-fsd",
-  "version": "3.0.1-canary.0",
+  "version": "3.0.1",
   "description": "A smart ESLint plugin that helps you enforce and maintain Feature-Sliced Design (FSD) architecture. Automatically validates layer hierarchy and import boundaries to prevent architectural leaks.",
   "license": "MIT",
   "author": "Oleg Putseiko <oleg.putseiko@gmail.com> (https://github.com/oleg-putseiko)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-import-fsd",
-  "version": "3.0.0",
+  "version": "3.0.1-canary.0",
   "description": "A smart ESLint plugin that helps you enforce and maintain Feature-Sliced Design (FSD) architecture. Automatically validates layer hierarchy and import boundaries to prevent architectural leaks.",
   "license": "MIT",
   "author": "Oleg Putseiko <oleg.putseiko@gmail.com> (https://github.com/oleg-putseiko)",

--- a/src/rules/no-deprecated-layers.ts
+++ b/src/rules/no-deprecated-layers.ts
@@ -56,12 +56,15 @@ export const noDeprecatedLayersRule: Rule.RuleModule = {
       const isDeprecated = DEPRECATED_LAYER_NAMES.includes(fileCtx.layer);
 
       if (isDeprecated && !isIgnored) {
-        listener.Program = (node) => {
+        listener.Program = () => {
           const layer = LAYERS[fileCtx.layerIndex];
           const isReplaceable = layer.displayedActualNames.length > 0;
 
           context.report({
-            node,
+            loc: {
+              start: { line: 1, column: 0 },
+              end: { line: 1, column: 1 },
+            },
             messageId: isReplaceable ? 'replaceableDeprecatedFileLayer' : 'deprecatedFileLayer',
             data: {
               deprecatedLayer: fileCtx.layer,

--- a/src/rules/no-unknown-layers.ts
+++ b/src/rules/no-unknown-layers.ts
@@ -46,9 +46,12 @@ export const noUnknownLayersRule: Rule.RuleModule = {
       const isIgnored = ignoredLayers.includes(fileCtx.layer);
 
       if (isUnknown && !isIgnored) {
-        listener.Program = (node) => {
+        listener.Program = () => {
           ruleContext.report({
-            node,
+            loc: {
+              start: { line: 1, column: 0 },
+              end: { line: 1, column: 1 },
+            },
             messageId: 'unknownFileLayer',
             data: { layer: fileCtx.layer },
           });


### PR DESCRIPTION
📝 **Description**

Improved the error highlight range for files violating FSD architecture. 

Previously, placing a file in an incorrect layer would highlight the entire file content, degrading code readability in IDEs and masking other linter errors. The error is now neatly localized to the first character of the file (`loc: { line: 1, column: 0 }`).

🔗 **Related Issue**

Closes #26 

🔍 **Type of Change**

- [x] 🐛 Bug fix (non-breaking change which fixes an issue, e.g., fixing a false positive)
- [ ] ✨ New feature (e.g., new config or rule addition)
- [ ] 💥 Breaking change (e.g., turning a 'warn' into an 'error', or removing a rule entirely)
- [ ] 🛡️ Security fix (e.g., patching a vulnerability or upgrading compromised dependencies)
- [x] 📚 Documentation update
- [ ] 🛠️ Refactoring / Chore (e.g., dependency updates, internal scripts)

✅ **Checklist**

- [x] I have targeted the `canary` branch.
- [x] My commit messages follow the Conventional Commits standard.
- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have run `yarn install` to ensure lockfile integrity (if dependencies changed).
- [x] I have run `yarn typecheck` and `yarn build` successfully.
- [x] I have run `yarn lint:fix` and my changes generate no new linting errors.

🧪 **How Has This Been Tested?**

- [x] Tested locally by applying the updated rule/config to a sample file and verifying the ESLint output.
- [x] Passed by unit/integration tests in the `tests/` directory.
